### PR TITLE
Fix default args for HR buckets

### DIFF
--- a/src/hrm/bt_client.py
+++ b/src/hrm/bt_client.py
@@ -11,7 +11,6 @@ from typing import List
 import matplotlib.pyplot as plt
 from bleak import BleakClient, BleakScanner
 from dotenv import load_dotenv
-from pydantic import Field
 from qiniu import Auth as QiniuAuth
 from qiniu import put_file as QiniuPutFile
 
@@ -153,13 +152,8 @@ class BtClient:
 
     def get_heart_rate_bucket(
         self,
-        since_from: float = Field(
-            default=10.0,
-            description="The start time of the monitoring, default 10 seconds ago",
-        ),
-        bucket_size: float = Field(
-            default=1.0, description="The size of the bucket, default 1 second"
-        ),
+        since_from: float = 10.0,
+        bucket_size: float = 1.0,
     ) -> List[dict]:
         """Get the heart rate bucket of the given since_from time in seconds and bucket_size in seconds.
 

--- a/tests/mcp/test_bt_client.py
+++ b/tests/mcp/test_bt_client.py
@@ -139,6 +139,16 @@ def test_get_heart_rate_bucket(bt_client, data, expected):
         assert result == [{"time": d[0], "value": math.ceil(d[1])} for d in data]
 
 
+def test_get_heart_rate_bucket_defaults(bt_client):
+    with (
+        patch("time.time", return_value=10.0),
+        patch.object(bt_client.db, "time_bucket", return_value=[(1.0, 60.0)]) as mock_tb,
+    ):
+        result = bt_client.get_heart_rate_bucket()
+        assert result == [{"time": 1.0, "value": 60}]
+        mock_tb.assert_called_once_with(0.0, 10.0, 1.0)
+
+
 @pytest.mark.parametrize(
     "data,expected",
     [


### PR DESCRIPTION
## Summary
- set `since_from` and `bucket_size` defaults in `BtClient.get_heart_rate_bucket`
- update unit tests to ensure the method works without explicit arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412746a2ac83299450d86115767ae7