### PR TITLE
Fix chart bucketing logic

### DIFF
--- a/src/hrm/bt_client.py
+++ b/src/hrm/bt_client.py
@@ -222,7 +222,7 @@ class BtClient:
 
         bucket_len = since_from / bucket_size
         if bucket_len > 60:
-            bucket_size = int(since_from / 60)
+            bucket_size = math.ceil(since_from / 60)
         else:
             bucket_size = 1
         data = self.get_heart_rate_bucket(

--- a/tests/mcp/test_bt_client.py
+++ b/tests/mcp/test_bt_client.py
@@ -198,6 +198,20 @@ def test_build_heart_rate_chart_upload_fail(mock_plt, mock_upload_file, bt_clien
         mock_plt.savefig.assert_called()
 
 
+@patch("hrm.bt_client.upload_file", return_value="http://fake.url/chart.png")
+@patch("hrm.bt_client.plt")
+def test_build_heart_rate_chart_bucket_size(mock_plt, mock_upload_file, bt_client):
+    with patch.object(
+        bt_client,
+        "get_heart_rate_bucket",
+        return_value=[{"time": 1, "value": 60}],
+    ) as mock_bucket:
+        since = 100.0
+        url = bt_client.build_heart_rate_chart(since_from=since)
+        assert url == "http://fake.url/chart.png"
+        mock_bucket.assert_called_once_with(since_from=since, bucket_size=math.ceil(since / 60))
+
+
 def test_upload_file_success(monkeypatch):
     # Set up environment variables
     monkeypatch.setenv("QINIU_ACCESS_KEY", "fake_key")


### PR DESCRIPTION
## Summary
- fix bucket size calculation in `build_heart_rate_chart`
- add test to ensure bucket size is limited correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411458e48c8329a4f369cc68586367