### PR TITLE
Add build settings for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,10 @@ asyncio_default_fixture_loop_scope = "session"
 omit = [
     "tests/*"
 ]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/hrm/ts_db.py
+++ b/src/hrm/ts_db.py
@@ -59,7 +59,9 @@ class TsDB:
         """
         self.data.clear()
 
-    def time_bucket(self, start: float, end: float, bucket_size: float) -> List[tuple[float, float]]:
+    def time_bucket(
+        self, start: float, end: float, bucket_size: float
+    ) -> List[tuple[float, float]]:
         """
         Bucket the data from the given start timestamp to the given end timestamp into the given time bucket size.
         """

--- a/tests/mcp/test_bt_client.py
+++ b/tests/mcp/test_bt_client.py
@@ -6,8 +6,6 @@ import pytest
 
 from hrm.bt_client import HEART_RATE_SERVICE_UUID, BtClient, upload_file
 
-import os
-
 
 @pytest.fixture
 def bt_client():
@@ -192,6 +190,7 @@ def test_build_heart_rate_chart_upload_fail(mock_plt, mock_upload_file, bt_clien
         def fake_savefig(buf, format=None):
             if hasattr(buf, "write"):
                 buf.write("<svg>mocked</svg>")
+
         mock_plt.savefig.side_effect = fake_savefig
         # Call the method
         result = bt_client.build_heart_rate_chart(since_from=2.0)
@@ -211,7 +210,9 @@ def test_build_heart_rate_chart_bucket_size(mock_plt, mock_upload_file, bt_clien
         since = 100.0
         url = bt_client.build_heart_rate_chart(since_from=since)
         assert url == "http://fake.url/chart.png"
-        mock_bucket.assert_called_once_with(since_from=since, bucket_size=math.ceil(since / 60))
+        mock_bucket.assert_called_once_with(
+            since_from=since, bucket_size=math.ceil(since / 60)
+        )
 
 
 def test_upload_file_success(monkeypatch):
@@ -222,8 +223,12 @@ def test_upload_file_success(monkeypatch):
     monkeypatch.setenv("QINIU_BUCKET_DOMAIN", "http://fake.domain")
 
     # Patch QiniuAuth and QiniuPutFile
-    with patch("hrm.bt_client.QiniuAuth") as MockAuth, \
-         patch("hrm.bt_client.QiniuPutFile", return_value=({"key": "somekey"}, MagicMock())) as mock_put_file:
+    with (
+        patch("hrm.bt_client.QiniuAuth") as MockAuth,
+        patch(
+            "hrm.bt_client.QiniuPutFile", return_value=({"key": "somekey"}, MagicMock())
+        ) as mock_put_file,
+    ):
         mock_auth_instance = MockAuth.return_value
         mock_auth_instance.upload_token.return_value = "fake_token"
         file_path = "/tmp/test.png"

--- a/tests/mcp/test_ts_db.py
+++ b/tests/mcp/test_ts_db.py
@@ -115,9 +115,13 @@ def test_query_invalid_range():
     db = TsDB()
     db.insert(1.0, 10.0)
     db.insert(2.0, 20.0)
-    with pytest.raises(ValueError, match="Start timestamp must be less than end timestamp"):
+    with pytest.raises(
+        ValueError, match="Start timestamp must be less than end timestamp"
+    ):
         db.query(2.0, 2.0)
-    with pytest.raises(ValueError, match="Start timestamp must be less than end timestamp"):
+    with pytest.raises(
+        ValueError, match="Start timestamp must be less than end timestamp"
+    ):
         db.query(3.0, 2.0)
 
 


### PR DESCRIPTION
## Summary
- configure build-system and package discovery
- format source and test files with `black`

## Testing
- `uv run ruff check src tests`
- `uv run black --check src tests`
- `uv run pytest -q`
- `uv run coverage run -m pytest`
- `uv run coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_6850d52cb024832983460963e2c086ee