### PR TITLE
Implement CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ The following environment variables are used:
 ## Run the server
 
 ```bash
-uv run src/hcm/server.py
+uv run src/hrm/server.py
+```
+
+After installing from PyPI you can also run the server directly using
+`uvx`:
+
+```bash
+uvx ble-hrm-server
 ```
 
 ## Run the tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "qiniu>=7.16.0",
 ]
 
+[project.scripts]
+ble-hrm-server = "hrm.__main__:main"
+
 [tool.uv]
 dev-dependencies = [
     "pytest>=8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ble-hrm-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "A MCP server, which serve as a BLE heart rate monitoring to connect with a HRM device."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/hrm/__main__.py
+++ b/src/hrm/__main__.py
@@ -1,0 +1,19 @@
+"""Command line entry point for ble-hrm-server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from fastmcp.cli.run import run_command
+
+from . import server
+
+
+def main() -> None:
+    """Run the bundled MCP server."""
+    run_command(str(Path(server.__file__).resolve()), server_args=sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a command line entrypoint via `hrm.__main__`
- expose script `ble-hrm-server` in project metadata
- document how to run the server

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850d63ed8c4832986eb1e421a3cc6f4