### PR TITLE
Fix CLI entrypoint and resource description

### DIFF
--- a/src/hrm/__main__.py
+++ b/src/hrm/__main__.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
-from fastmcp.cli.run import run_command
+from fastmcp.cli.cli import app
 
 from . import server
 
 
 def main() -> None:
     """Run the bundled MCP server."""
-    run_command(str(Path(server.__file__).resolve()), server_args=sys.argv[1:])
+    app(
+        args=["run", str(Path(server.__file__).resolve()), *sys.argv[1:]],
+        standalone_mode=False,
+    )
 
 
 if __name__ == "__main__":

--- a/src/hrm/server.py
+++ b/src/hrm/server.py
@@ -16,7 +16,7 @@ mcp.add_resource(
     FunctionResource(
         uri="discover://hrm",
         name="HRM Device",
-        text="Bluetooth Heart Rate Monitor Devices",
+        description="Bluetooth Heart Rate Monitor Devices",
         fn=cli.list_bluetooth_devices,
     )
 )


### PR DESCRIPTION
## Summary
- fix call to `FunctionResource` in server module
- update CLI entrypoint to use `fastmcp` Typer app

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68510090f46c8329a31ab868693adb68